### PR TITLE
fix: different loading order on new game

### DIFF
--- a/BoardMap.cs
+++ b/BoardMap.cs
@@ -38,8 +38,7 @@ public partial class BoardMap : TileMap
         PieceNode piece = PieceScene.Instantiate<PieceNode>();
         AddChild(piece);
 
-		piece.Team = team;
-		piece.PieceType = type;
+		piece.ConfigurePiece(team, type);
 
         tile.AddPiece(piece);
 
@@ -176,8 +175,7 @@ public partial class BoardMap : TileMap
         PieceNode piece = PieceScene.Instantiate<PieceNode>();
         AddChild(piece);
 
-        piece.PieceType = _gameMaster.SelectedPieceType;
-        piece.Team = Team.Blue;
+		piece.ConfigurePiece(Team.Blue, _gameMaster.SelectedPieceType);
 
         tile.AddPiece(piece);
         _gameMaster.AssignPiece();

--- a/PieceNode.cs
+++ b/PieceNode.cs
@@ -85,11 +85,6 @@ public partial class PieceNode : Node2D
         { 
             _pieceType = value;
 
-            setTooltipText();
-
-            if (Team == Team.Blue)
-                SetSprite();
-
             switch (_pieceType) 
             {
                 case PieceType.General:
@@ -141,11 +136,22 @@ public partial class PieceNode : Node2D
 
         setTooltipText();
         setShaderColor();
-	}
+    }
 
 	// Called every frame. 'delta' is the elapsed time since the previous frame.
 	public override void _Process(double delta)
 	{
+    }
+
+    internal void ConfigurePiece(Team team, PieceType pieceType)
+    {
+        Team = team;
+        PieceType = pieceType;
+
+        setTooltipText();
+
+        if (Team == Team.Blue)
+            SetSprite();
     }
 
     private void SetSprite()
@@ -153,6 +159,7 @@ public partial class PieceNode : Node2D
         if (_sprite == null)
             return;
 
+        // In future I could probably just load/set the texture using piecetype if I rename the files
         switch (_pieceType)
         {
             case PieceType.Landmine:


### PR DESCRIPTION
Implements a proper method for configuring a piece.
Handles case where blue team pieces would show sprites on load, but not on placing a piece in a new game.